### PR TITLE
fix(auth): remove imports duplicados no middleware

### DIFF
--- a/backend/src/middlewares/auth.js
+++ b/backend/src/middlewares/auth.js
@@ -1,9 +1,6 @@
 const jwt = require('jsonwebtoken');
 const Usuario = require('../models/Usuario');
 
-const jwt = require('jsonwebtoken');
-const Usuario = require('../models/Usuario');
-
 // Middleware para proteger rotas - verifica se o usuário está autenticado
 const protect = async (req, res, next) => {
     let token;


### PR DESCRIPTION
Problema: SyntaxError 'jwt' has already been declared
Solução: Remove declarações duplicadas de jwt e Usuario

Impacto: Resolve crash do servidor Node.js ao inicializar
Causa: Duplicação acidental durante edições de logging anteriores